### PR TITLE
Rename classes

### DIFF
--- a/jsonserializable.py
+++ b/jsonserializable.py
@@ -130,7 +130,7 @@ class ContainerBase(Serializable, metaclass=ContainerMeta):
             ))
 
 
-class Array(ContainerBase, list):
+class List(ContainerBase, list):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -161,7 +161,7 @@ class Array(ContainerBase, list):
         return cls(deserialize(entry, cls._container_type) for entry in data)
 
 
-class Mapping(ContainerBase, dict):
+class Dict(ContainerBase, dict):
 
     @staticmethod
     def _check_key_type(key):

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,22 +1,22 @@
 import pytest
 from jsonschema import ValidationError
-from jsonserializable import Mapping
+from jsonserializable import Dict
 
 
 @pytest.mark.parametrize('data', [{}, {'one': 1, 'two': 2}])
 def test_serialize(data):
-    mapping = Mapping[int](data)
-    assert mapping.serialize() == data
+    obj = Dict[int](data)
+    assert obj.serialize() == data
 
 
 @pytest.mark.parametrize('data', [{}, {'one': 1, 'two': 2}])
 def test_deserialize(data):
-    mapping = Mapping[int].deserialize(data)
-    assert mapping == Mapping[int](data)
+    obj = Dict[int].deserialize(data)
+    assert obj == Dict[int](data)
 
 
 def test_schema():
-    assert Mapping[int].schema() == {
+    assert Dict[int].schema() == {
         'type': 'object',
         'additionalProperties': {'type': 'number'}
     }
@@ -29,7 +29,7 @@ def test_schema():
 ])
 def test_construct_invalid_type(data):
     with pytest.raises(TypeError):
-        Mapping[int](data)
+        Dict[int](data)
 
 
 @pytest.mark.parametrize('data', [
@@ -40,73 +40,73 @@ def test_construct_invalid_type(data):
 ])
 def test_deserialize_invalid_schema(data):
     with pytest.raises(ValidationError):
-        Mapping[int].deserialize(data)
+        Dict[int].deserialize(data)
 
 
 def test_deserialize_invalid_key_type():
     with pytest.raises(TypeError):
-        Mapping[int].deserialize({1: 1})
+        Dict[int].deserialize({1: 1})
 
 
 def test_repr():
-    assert repr(Mapping[int](one=1)) == "Mapping[int]({'one': 1})"
+    assert repr(Dict[int](one=1)) == "Dict[int]({'one': 1})"
 
 
 def test_setitem():
-    mapping = Mapping[int]()
-    mapping['foo'] = 1
-    assert mapping['foo'] == 1
+    obj = Dict[int]()
+    obj['foo'] = 1
+    assert obj['foo'] == 1
 
 
 @pytest.mark.parametrize('key', [1, ['foo']])
 def test_setitem_invalid_key_type(key):
-    mapping = Mapping[int]()
+    obj = Dict[int]()
     with pytest.raises(TypeError):
-        mapping[key] = 1
+        obj[key] = 1
 
 
 @pytest.mark.parametrize('value', ['bar', [1]])
 def test_setitem_invalid_value_type(value):
-    mapping = Mapping[int]()
+    obj = Dict[int]()
     with pytest.raises(TypeError):
-        mapping['foo'] = value
+        obj['foo'] = value
 
 
 def test_no_type_argument():
     with pytest.raises(TypeError):
-        Mapping()
+        Dict()
 
 
 @pytest.mark.parametrize('typearg', [bytes, 'foo'])
 def test_unsupported_type_argument(typearg):
     with pytest.raises(TypeError):
-        Mapping[typearg]
+        Dict[typearg]
 
 
 def test_second_type_argument():
     with pytest.raises(TypeError):
-        Mapping[int][int]
+        Dict[int][int]
 
 
-class IntMapping(Mapping[int]):  # type: ignore
+class IntDict(Dict[int]):  # type: ignore
     pass
 
 
-@pytest.mark.parametrize('value', [Mapping[int](one=1), IntMapping(one=1)])
+@pytest.mark.parametrize('value', [Dict[int](one=1), IntDict(one=1)])
 def test_isinstance_true(value):
-    assert isinstance(value, Mapping)
-    assert isinstance(value, Mapping[int])
+    assert isinstance(value, Dict)
+    assert isinstance(value, Dict[int])
 
 
 def test_isinstance_false():
-    assert not isinstance(Mapping[int](one=1), IntMapping)
+    assert not isinstance(Dict[int](one=1), IntDict)
 
 
-@pytest.mark.parametrize('cls', [Mapping[int], IntMapping])
+@pytest.mark.parametrize('cls', [Dict[int], IntDict])
 def test_issubclass_true(cls):
-    assert issubclass(cls, Mapping)
-    assert issubclass(cls, Mapping[int])
+    assert issubclass(cls, Dict)
+    assert issubclass(cls, Dict[int])
 
 
 def test_issubclass_false():
-    assert not issubclass(Mapping[int], IntMapping)
+    assert not issubclass(Dict[int], IntDict)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,5 +1,5 @@
 import pytest
-from jsonserializable import serialize, deserialize, schema, Array, Mapping
+from jsonserializable import serialize, deserialize, schema, List, Mapping
 
 
 @pytest.mark.parametrize('value, expected', [
@@ -7,7 +7,7 @@ from jsonserializable import serialize, deserialize, schema, Array, Mapping
     (3.4, 3.4),
     ('foo', 'foo'),
     (True, True),
-    (Array[int]([1, 2]), [1, 2]),
+    (List[int]([1, 2]), [1, 2]),
     (Mapping[int](foo=1), {'foo': 1})
 ])
 def test_serialize(value, expected):
@@ -26,7 +26,7 @@ def test_serialize_unsupported():
     (3.4, float, 3.4),
     ('foo', str, 'foo'),
     (True, bool, True),
-    ([1, 2], Array[int], Array[int]([1, 2])),
+    ([1, 2], List[int], List[int]([1, 2])),
     ({'foo': 1}, Mapping[int], Mapping[int](foo=1))
 ])
 def test_deserialize(value, target_type, expected):
@@ -45,7 +45,7 @@ def test_deserialize_unsupported():
     (float, {'type': 'number'}),
     (str, {'type': 'string'}),
     (bool, {'type': 'boolean'}),
-    (Array[int], Array[int].schema()),
+    (List[int], List[int].schema()),
     (Mapping[int], Mapping[int].schema())
 ])
 def test_schema(python_type, expected):

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,5 +1,5 @@
 import pytest
-from jsonserializable import serialize, deserialize, schema, List, Mapping
+from jsonserializable import serialize, deserialize, schema, List, Dict
 
 
 @pytest.mark.parametrize('value, expected', [
@@ -8,7 +8,7 @@ from jsonserializable import serialize, deserialize, schema, List, Mapping
     ('foo', 'foo'),
     (True, True),
     (List[int]([1, 2]), [1, 2]),
-    (Mapping[int](foo=1), {'foo': 1})
+    (Dict[int](foo=1), {'foo': 1})
 ])
 def test_serialize(value, expected):
     serialized = serialize(value)
@@ -27,7 +27,7 @@ def test_serialize_unsupported():
     ('foo', str, 'foo'),
     (True, bool, True),
     ([1, 2], List[int], List[int]([1, 2])),
-    ({'foo': 1}, Mapping[int], Mapping[int](foo=1))
+    ({'foo': 1}, Dict[int], Dict[int](foo=1))
 ])
 def test_deserialize(value, target_type, expected):
     deserialized = deserialize(value, target_type)
@@ -46,7 +46,7 @@ def test_deserialize_unsupported():
     (str, {'type': 'string'}),
     (bool, {'type': 'boolean'}),
     (List[int], List[int].schema()),
-    (Mapping[int], Mapping[int].schema())
+    (Dict[int], Dict[int].schema())
 ])
 def test_schema(python_type, expected):
     assert schema(python_type) == expected

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,22 +1,22 @@
 import pytest
 from jsonschema import ValidationError
-from jsonserializable import Array
+from jsonserializable import List
 
 
 @pytest.mark.parametrize('data', [[], [1, 2, 3]])
 def test_serialize(data):
-    array = Array[int](data)
-    assert array.serialize() == data
+    obj = List[int](data)
+    assert obj.serialize() == data
 
 
 @pytest.mark.parametrize('data', [[], [1, 2, 3]])
 def test_deserialize(data):
-    array = Array[int].deserialize(data)
-    assert array == Array[int](data)
+    obj = List[int].deserialize(data)
+    assert obj == List[int](data)
 
 
 def test_schema():
-    assert Array[int].schema() == {
+    assert List[int].schema() == {
         'type': 'array',
         'items': {'type': 'number'}
     }
@@ -25,82 +25,82 @@ def test_schema():
 @pytest.mark.parametrize('data', [['foo'], [1, 2, 'bar']])
 def test_construct_invalid_type(data):
     with pytest.raises(TypeError):
-        Array[int](data)
+        List[int](data)
 
 
 @pytest.mark.parametrize('data', [['foo'], [1, 2, 'bar'], {}, 1])
 def test_deserialize_invalid_schema(data):
     with pytest.raises(ValidationError):
-        Array[int].deserialize(data)
+        List[int].deserialize(data)
 
 
 def test_repr():
-    assert repr(Array[int]([1, 2, 3])) == 'Array[int]([1, 2, 3])'
+    assert repr(List[int]([1, 2, 3])) == 'List[int]([1, 2, 3])'
 
 
 def test_setitem():
-    array = Array[int]([1, 2, 3])
-    array[1] = 10
-    assert array[1] == 10
-    assert len(array) == 3
+    obj = List[int]([1, 2, 3])
+    obj[1] = 10
+    assert obj[1] == 10
+    assert len(obj) == 3
 
 
 @pytest.mark.parametrize('data', ['foo', [], [1]])
 def test_setitem_invalid_type(data):
-    array = Array[int]([1, 2, 3])
+    obj = List[int]([1, 2, 3])
     with pytest.raises(TypeError):
-        array[1] = data
+        obj[1] = data
 
 
 def test_insert():
-    array = Array[int]([1, 2, 3])
-    array.insert(1, 10)
-    assert array[1] == 10
-    assert len(array) == 4
+    obj = List[int]([1, 2, 3])
+    obj.insert(1, 10)
+    assert obj[1] == 10
+    assert len(obj) == 4
 
 
 @pytest.mark.parametrize('data', ['foo', [], [1]])
 def test_insert_invalid_type(data):
-    array = Array[int]([1, 2, 3])
+    obj = List[int]([1, 2, 3])
     with pytest.raises(TypeError):
-        array.insert(1, data)
+        obj.insert(1, data)
 
 
 def test_no_type_argument():
     with pytest.raises(TypeError):
-        Array()
+        List()
 
 
 @pytest.mark.parametrize('typearg', [bytes, 'foo'])
 def test_unsupported_type_argument(typearg):
     with pytest.raises(TypeError):
-        Array[typearg]
+        List[typearg]
 
 
 def test_second_type_argument():
     with pytest.raises(TypeError):
-        Array[int][int]
+        List[int][int]
 
 
-class IntArray(Array[int]):  # type: ignore
+class IntList(List[int]):  # type: ignore
     pass
 
 
-@pytest.mark.parametrize('value', [Array[int]([1, 2]), IntArray([1, 2])])
+@pytest.mark.parametrize('value', [List[int]([1, 2]), IntList([1, 2])])
 def test_isinstance_true(value):
-    assert isinstance(value, Array)
-    assert isinstance(value, Array[int])
+    assert isinstance(value, List)
+    assert isinstance(value, List[int])
 
 
 def test_isinstance_false():
-    assert not isinstance(Array[int]([1, 2]), IntArray)
+    assert not isinstance(List[int]([1, 2]), IntList)
 
 
-@pytest.mark.parametrize('cls', [Array[int], IntArray])
+@pytest.mark.parametrize('cls', [List[int], IntList])
 def test_issubclass_true(cls):
-    assert issubclass(cls, Array)
-    assert issubclass(cls, Array[int])
+    assert issubclass(cls, List)
+    assert issubclass(cls, List[int])
 
 
 def test_issubclass_false():
-    assert not issubclass(Array[int], IntArray)
+    assert not issubclass(List[int], IntList)


### PR DESCRIPTION
Change typed class names from Array and Mapping to List and Dict. This is aimed at making the names more aligned with Python nomenclature and less aligned with JSON. The fact that the types are serializable to JSON is meant to be inconsequential.